### PR TITLE
Update rulesets.js

### DIFF
--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -18,7 +18,7 @@ exports.BattleFormats = {
 	},
 	standardubers: {
 		effectType: 'Banlist',
-		ruleset: ['Sleep Clause Mod', 'Species Clause', 'Moody Clause', 'OHKO Clause', 'Endless Battle Clause', 'HP Percentage Mod'],
+		ruleset: ['Sleep Clause Mod', 'Species Clause', 'Moody Clause', 'OHKO Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Evasion Moves Clause'],
 		banlist: ['Unreleased', 'Illegal', 'Huntail + Shell Smash + Sucker Punch', 'Leavanny + Knock Off + Sticky Web', 'Sylveon + Hyper Voice + Heal Bell + Wish + Baton Pass']
 	},
 	standardgbu: {


### PR DESCRIPTION
Added 'Evasion Moves Clause' to enforce the ban of Evasion moves. This mirrors PokeBattle's rules, but does not require 'Evasion Abilities Clause' because only Moody is banned under the Evasion Clause in terms of abilities.
