### PR TITLE
Edited PBV Typo in /dt

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -319,7 +319,7 @@ var commands = exports.commands = {
 					"Weight": pokemon.weightkg + " kg <em>(" + weighthit + " BP)</em>",
 					"Dex Colour": pokemon.color,
 					"Egg Group(s)": pokemon.eggGroups.join(", "),
-					"PBV: ": pokemon.pokebattlevalue
+					"PBV": pokemon.pokebattlevalue
 				};
 				if (!pokemon.evos.length) {
 					details["<font color=#585858>Does Not Evolve</font>"] = "";


### PR DESCRIPTION
Originally (at line 322) there was "PBV: ": pokemon.pokebattlevalue listed, which does display the PBV, but it also presented it as PBV: : 335 every time it was called. So it was fixed to display the value without a typo.
